### PR TITLE
Add support for `repositories:` alias in config

### DIFF
--- a/lib/herdsman/config.rb
+++ b/lib/herdsman/config.rb
@@ -8,7 +8,7 @@ module Herdsman
     end
 
     def repos
-      config_repos = config['repos'] || []
+      config_repos = config['repos'] || config['repositories'] || []
       config_repos.map do |repo_config|
         RepoConfig.new(repo_config)
       end

--- a/spec/fixtures/config/repositories-alias/herdsman.yml
+++ b/spec/fixtures/config/repositories-alias/herdsman.yml
@@ -1,0 +1,3 @@
+repositories:
+  - path: /tmp
+    revision: a-branch

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -23,6 +23,15 @@ describe Herdsman::Config do
         expect(config.repos[0].revision).to eq('a-branch')
       end
     end
+
+    context 'with repositories alias' do
+      it 'returns a list of repo objects' do
+        config = described_class.new(config_fixture_path('repositories-alias'))
+
+        expect(config.repos.is_a?(Array)).to be true
+        expect(config.repos.size).to be(1)
+      end
+    end
   end
 
   context 'with undefined repos' do


### PR DESCRIPTION
#### Because:

* Some might prefer it to `repos:`.