### PR TITLE
Add support for global defaults in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 * `--fetch-cache=SECONDS`/`-c` option.
 * `--revision`/`-r` option.
+* `defaults:` config with support for `revision:` and `fetch_cache:`.
 
 ## [v0.2.0] - 2017-03-01
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ Configure the herd of repositories to manage with a `herdsman.yml` file in the c
 Example:
 
 ```yml
+defaults:
+  revision: not-master
+  fetch_cache: 300
+
 repos:
   - /path/to/foo-repo
   - ../../path/to/bar-repo

--- a/lib/herdsman/config.rb
+++ b/lib/herdsman/config.rb
@@ -11,8 +11,9 @@ module Herdsman
 
     def repos
       config_repos = config['repos'] || config['repositories'] || []
+      defaults = config['defaults'] || {}
       config_repos.map do |herd_member_config|
-        HerdMemberConfig.new(herd_member_config, overrides)
+        HerdMemberConfig.new(herd_member_config, overrides, defaults)
       end
     end
 

--- a/lib/herdsman/herd_member_config.rb
+++ b/lib/herdsman/herd_member_config.rb
@@ -1,8 +1,9 @@
 module Herdsman
   class HerdMemberConfig
-    def initialize(args = {}, overrides = {})
+    def initialize(args = {}, overrides = {}, defaults = {})
       @args      = args
       @overrides = overrides
+      @defaults  = defaults
       validate!
     end
 
@@ -32,18 +33,24 @@ module Herdsman
 
     private
 
-    attr_reader :args, :overrides
+    attr_reader :args, :overrides, :defaults
 
     def default_name
       File.basename(path)
     end
 
     def default_revision
-      'master'
+      overridable_default('revision', 'master')
     end
 
     def default_fetch_cache
-      0
+      overridable_default('fetch_cache', 0)
+    end
+
+    def overridable_default(arg, default)
+      defaults.fetch(arg)
+    rescue
+      default
     end
 
     def overridable_arg(arg)

--- a/spec/fixtures/config/defaults/herdsman.yml
+++ b/spec/fixtures/config/defaults/herdsman.yml
@@ -1,0 +1,7 @@
+defaults:
+  revision: a-tag
+  fetch_cache: 300
+
+repos:
+  - path: /tmp
+    revision: a-branch

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -27,7 +27,20 @@ describe Herdsman::Config do
       overrides = { fetch_cache: 300 }
       config = described_class.new(config_fixture_path('valid'), overrides)
 
-      expect(Herdsman::HerdMemberConfig).to receive(:new).with(args, overrides)
+      expect(Herdsman::HerdMemberConfig).to receive(:new).with(args, overrides,
+                                                               {})
+      config.repos
+    end
+  end
+
+  context 'with defaults' do
+    it 'passes the defaults to HerdMemberConfig' do
+      config = described_class.new(config_fixture_path('defaults'))
+      args = { 'path' => '/tmp', 'revision' => 'a-branch' }
+      defaults = { 'revision' => 'a-tag', 'fetch_cache' => 300 }
+
+      expect(Herdsman::HerdMemberConfig).to receive(:new).with(args, {},
+                                                               defaults)
       config.repos
     end
   end

--- a/spec/unit/herd_member_config_spec.rb
+++ b/spec/unit/herd_member_config_spec.rb
@@ -56,6 +56,22 @@ describe Herdsman::HerdMemberConfig do
         expect(repo_config.revision).to eq('foo-revision')
       end
     end
+    context 'with default' do
+      it 'favours the arg value' do
+        args = { 'path' => '/foo/path', 'revision' => 'foo' }
+        defaults = { 'revision' => 'bar' }
+        herd_member_config = described_class.new(args, {}, defaults)
+
+        expect(herd_member_config.revision).to eq('foo')
+      end
+      it 'returns the specified value if no arg provided' do
+        args = { 'path' => '/foo/path' }
+        defaults = { 'revision' => 'bar' }
+        herd_member_config = described_class.new(args, {}, defaults)
+
+        expect(herd_member_config.revision).to eq('bar')
+      end
+    end
   end
   describe '#fetch_cache' do
     it 'defaults to 0' do
@@ -95,6 +111,22 @@ describe Herdsman::HerdMemberConfig do
         repo_config = described_class.new(args, overrides)
 
         expect(repo_config.fetch_cache).to eq(300)
+      end
+    end
+    context 'with default' do
+      it 'favours the arg value' do
+        args = { 'path' => '/foo/path', 'fetch_cache' => 300 }
+        defaults = { 'fetch_cache' => 100 }
+        herd_member_config = described_class.new(args, {}, defaults)
+
+        expect(herd_member_config.fetch_cache).to eq(300)
+      end
+      it 'returns the specified value if no arg provided' do
+        args = { 'path' => '/foo/path' }
+        defaults = { 'fetch_cache' => 100 }
+        herd_member_config = described_class.new(args, {}, defaults)
+
+        expect(herd_member_config.fetch_cache).to eq(100)
       end
     end
   end


### PR DESCRIPTION
#### This change:

* Add support overridding the hardcoded defaults for `revision:` and
  `fetch_cache:` with a `defaults:` hash in the config file.