### PR TITLE
Add `thor` to gemspec dependencies

### DIFF
--- a/herdsman.gemspec
+++ b/herdsman.gemspec
@@ -3,6 +3,7 @@ $LOAD_PATH.unshift lib unless $LOAD_PATH.include?(lib)
 require 'herdsman/version'
 
 Gem::Specification.new do |spec|
+  spec.add_dependency 'thor', '~> 0.19.0'
   spec.authors       = ['Tom Marshall']
   spec.description   =
     'Herdsman is a CLI utility for working with multiple Git repositories'


### PR DESCRIPTION
#### Because:

* It's a required dependency, and it's missing.
* Currently `gem install herdsman` will not ensure that `thor` is also
  present.